### PR TITLE
Add web3 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mako
 requests
 maya
 appdirs
+web3

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ setup(
         'mako',
         'requests',
         'maya',
-        'appdirs'
+        'appdirs',
+        'web3'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
When running `nucypher-ops ursula defund` I got:
```
  File "/Users/jamescampbell/.local/pipx/venvs/nucypher-ops/lib/python3.10/site-packages/nucypher_ops/ops/fleet_ops.py", line 64, in inner
    w3 = web3.Web3(web3.Web3.HTTPProvider(provider))
UnboundLocalError: local variable 'web3' referenced before assignment
```