### PR TITLE
Add config migration step for updating existing Ursula

### DIFF
--- a/nucypher_ops/playbooks/include/update_existing_ursula.yml
+++ b/nucypher_ops/playbooks/include/update_existing_ursula.yml
@@ -22,4 +22,11 @@
         source: pull
         force_source: yes
 
+    - name: Run config migrations
+      become: yes
+      become_user: nucypher
+      command: "docker run -v /home/nucypher:/root/.local/share/ \
+        -it {{ docker_image | default('nucypher/nucypher:latest') }} \
+        nucypher ursula config migrate"
+
 - import_playbook: run_ursula.yml


### PR DESCRIPTION
This should only be merged after https://github.com/nucypher/nucypher/pull/3207
I'm realising that this now ties `nucypher-ops` versions to `nucypher` versions