### PR TITLE
tbtcv2 arg compat fix

### DIFF
--- a/nucypher_ops/templates/porter_inventory.mako
+++ b/nucypher_ops/templates/porter_inventory.mako
@@ -17,8 +17,8 @@ all:
                   %for attr in node['provider_deploy_attrs']:
                   ${attr['key']}: ${attr['value']}
                   %endfor
-                  % if node.get('eth_provider'):
-                  eth_provider: ${node['eth_provider']}
+                  % if node.get('eth_endpoint'):
+                  eth_provider: ${node['eth_endpoint']}
                   %endif
                   %if node.get('docker_image'):
                   docker_image: ${node['docker_image']}

--- a/nucypher_ops/templates/tbtcv2_inventory.mako
+++ b/nucypher_ops/templates/tbtcv2_inventory.mako
@@ -20,8 +20,8 @@ all:
                   %for attr in node['provider_deploy_attrs']:
                   ${attr['key']}: ${attr['value']}
                   %endfor
-                  % if node.get('eth_provider'):
-                  eth_provider: ${node['eth_provider']}
+                  % if node.get('eth_endpoint'):
+                  eth_provider: ${node['eth_endpoint']}
                   %endif
                   %if node.get('docker_image'):
                   docker_image: ${node['docker_image']}


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
Found a bug when doing: `nucypher-ops tbtcv2 run` 
the arg name mismatch was causing an Ansible "this variable does not exist" error.
Deployment failed.  This patch allows it to succeed with no additional changes.

this commit was made for Ursula:
https://github.com/nucypher/nucypher-ops/blame/326e2918ff583bb5a11bb097ea9737720d00fd3d/nucypher_ops/templates/ursula_inventory.mako#L36

This PR does the same for tbtcv2 _and_ Porter

