### PR TITLE
Change IP lookup webservice to one that preferably returns IPv4 over …

### DIFF
--- a/nucypher_ops/playbooks/include/check_running_ursula.yml
+++ b/nucypher_ops/playbooks/include/check_running_ursula.yml
@@ -6,7 +6,7 @@
 
     - name: Get public ip
       uri:
-        url: http://ifconfig.me/ip
+        url: https://api.ipify.org
         return_content: yes
       register: ip_response
 

--- a/nucypher_ops/playbooks/include/init_ursula.yml
+++ b/nucypher_ops/playbooks/include/init_ursula.yml
@@ -58,7 +58,7 @@
 
     - name: Find my public ip
       uri:
-        url: http://ifconfig.me/ip
+        url: https://api.ipify.org
         return_content: yes
       register: ip_response
 

--- a/nucypher_ops/playbooks/include/run_ursula.yml
+++ b/nucypher_ops/playbooks/include/run_ursula.yml
@@ -38,7 +38,7 @@
 
     - name: Find my public ip
       uri:
-        url: http://ifconfig.me/ip
+        url: https://api.ipify.org
         return_content: yes
       register: ip_response
 


### PR DESCRIPTION
…IPv6, when both are available.

This is required as ursulas cli option for "rest-host" expects an IPv4 (see https://github.com/nucypher/nucypher/blob/736f8f9cbbe1eb06bb071b9d8eec6eacfc2e79a6/nucypher/utilities/networking.py#L42-L48)

**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

Changes the URI request URL to something accessible for hosts that contain both IPv6/IPv4 global interfaces, to return the IPv4 variant. 

**Issues fixed/closed:**
None

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

As long as TACo node does not accept IPv6 binding address for rest-host, this is a requirement for hosts that contain both IPv6/IPv4 global interfaces.

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

No. Only replacement of ip lookup webservice that is queried for IPv4 public address. 